### PR TITLE
add babel-cli npm module as devDependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "devDependencies": {
         "babel": "^6.5.2",
         "babel-core": "^5.8.38",
+        "babel-cli": "^6.7.7",
         "babel-loader": "^5.4.0",
         "babel-preset-es2015": "^6.6.0",
         "css-loader": "^0.15.2",


### PR DESCRIPTION
What has changed:
- include the handy `babel-cli` npm module to `package.json` devDependencies. Nothing more.

Benefits:
- if using a WebStorm IDE, the ES6 style file `app/src/models/products.js` is prevented flagged up as syntax error by adding a new watcher within the IDE, with the program path set as `node_modules/babel-cli/bin/babel.js`.
